### PR TITLE
Updated conformity checks

### DIFF
--- a/build-tools/RunConformityChecks.ps1
+++ b/build-tools/RunConformityChecks.ps1
@@ -17,14 +17,14 @@ Invoke-Expression $command
 
 Write-Host "`nCheck for SolutionInfo.cs file"
 
-$command = ".\MatchFileText.ps1 -FileOrFolderPath ""..\Source\"" -SearchTextOrPattern '<Compile Include=""(.+)"">' -FilePattern ""*.csproj"" -Verbose" +
-    " -ValidMatchValues '..\SolutionInfo.cs','..\..\SolutionInfo.cs' -RecurseDirectory -ExcludeFilePattern 'Tests'"
+$command = ".\MatchFileText.ps1 -FileOrFolderPath ""..\Source\"" -SearchTextOrPattern '<Compile Include=""(.+)"">[\s\r\n]+<Link>Properties\\SolutionInfo.cs</Link>' -FilePattern ""*.csproj"" -Verbose" +
+    " -ValidMatchValues '..\SolutionInfo.cs','..\..\SolutionInfo.cs' -RecurseDirectory -ExcludeFilePattern 'Tests' -MultiLineSearch"
 
 Invoke-Expression $command
 
 Write-Host "`nCheck for proper build output"
 $command = ".\MatchFileText.ps1 -FileOrFolderPath ""..\Source\"" -SearchTextOrPattern 'Release[\W\w]+<OutputPath>(.+)</OutputPath>' -FilePattern ""*.csproj"" -Verbose" +
-    " -ValidMatchValues '..\..\Builds\','..\..\..\Builds\' -RecurseDirectory -ExcludeFilePattern 'Tests'"
+    " -ValidMatchValues '..\..\Builds\','..\..\..\Builds\' -RecurseDirectory -ExcludeFilePattern 'Tests' -MultiLineSearch"
 
 Invoke-Expression $command
 


### PR DESCRIPTION
The previous implementation had two problems: one, it assumed only one file specified under "Compile Include". Secondly, it only included one match per file, potentially missing true failures. This update:
- Fixes the issue with "Compile Include" which appeared due to the power servo code
- Improves results by implementing a multiline search flag

(cherry picked from commit cc22d386332886bb21a62eedab00728e2201a1f6)