### PR TITLE
CFR Addition to DPD

### DIFF
--- a/Source/Common/Common.cs
+++ b/Source/Common/Common.cs
@@ -44,6 +44,13 @@ namespace NationalInstruments.ReferenceDesignLibraries
         public bool IdleDurationPresent;
         public double RuntimeScaling;
         public string Script;
+
+        public void UpdateWaveformNameAndScript(string newName)
+        {
+            // Update the script with the new waveform name
+            Script = Script?.Replace(Name, newName);
+            Name = newName;
+        }
     }
     public enum LocalOscillatorSharingMode
     {

--- a/Source/Methods/RFmxDPD/RFmxDPD.cs
+++ b/Source/Methods/RFmxDPD/RFmxDPD.cs
@@ -6,7 +6,7 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
 {
     public static class RFmxDPD
     {
-        #region Type Definitionss
+        #region Type Definitions
         public struct PreDpdCrestFactorReductionCarrierChannel
         {
             public double Offset_Hz;
@@ -172,9 +172,8 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         {
             // Configure the new waveform
             Waveform preDpdCfrWaveform = referenceWaveform;
-            preDpdCfrWaveform.Name = referenceWaveform.Name + "preDPDCFR";
             preDpdCfrWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
-            preDpdCfrWaveform.Script = preDpdCfrWaveform.Script?.Replace(referenceWaveform.Name, preDpdCfrWaveform.Name);
+            preDpdCfrWaveform.UpdateWaveformNameAndScript(referenceWaveform.Name + "preDPDCFR");
 
             //Configure Pre-DPD CFR             
             RFmxSpecAnMXDpdApplyDpdIdleDurationPresent preDpdCfrIdlePresent = preDpdCfrWaveform.IdleDurationPresent ?
@@ -255,9 +254,8 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             {
                 PredistortedWaveform = referenceWaveform,
             };
-            lutResults.PredistortedWaveform.Name = referenceWaveform.Name + "postLutDpd";
             lutResults.PredistortedWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
-            lutResults.PredistortedWaveform.Script = lutResults.PredistortedWaveform.Script?.Replace(referenceWaveform.Name, lutResults.PredistortedWaveform.Name);
+            lutResults.PredistortedWaveform.UpdateWaveformNameAndScript(referenceWaveform.Name + "postLutDpd");
 
             RfsgGenerationStatus preDpdGenerationStatus = rfsgSession.CheckGenerationStatus();
             if (preDpdGenerationStatus == RfsgGenerationStatus.Complete)
@@ -292,9 +290,8 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             {
                 PredistortedWaveform = referenceWaveform
             };
-            mpResults.PredistortedWaveform.Name = referenceWaveform.Name + "postMpDpd";
             mpResults.PredistortedWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
-            mpResults.PredistortedWaveform.Script = mpResults.PredistortedWaveform.Script?.Replace(referenceWaveform.Name, mpResults.PredistortedWaveform.Name);
+            mpResults.PredistortedWaveform.UpdateWaveformNameAndScript(referenceWaveform.Name + "postMpDpd");
 
             RFmxSpecAnMXDpdApplyDpdIdleDurationPresent idlePresent = referenceWaveform.IdleDurationPresent ? RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
 

--- a/Source/Methods/RFmxDPD/RFmxDPD.cs
+++ b/Source/Methods/RFmxDPD/RFmxDPD.cs
@@ -38,7 +38,7 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             {
                 return new PreDpdCrestFactorReduction
                 {
-                    Enabled = RFmxSpecAnMXDpdPreDpdCfrEnabled.False,
+                    Enabled = RFmxSpecAnMXDpdPreDpdCfrEnabled.True,
                     Method = RFmxSpecAnMXDpdPreDpdCfrMethod.Clipping,
                     MaxIterations = 10,
                     TargetPapr_dB = 8,

--- a/Source/Methods/RFmxDPD/RFmxDPD.cs
+++ b/Source/Methods/RFmxDPD/RFmxDPD.cs
@@ -23,31 +23,31 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         }
         public struct PreDpdCrestFactorReduction
         {
-            public RFmxSpecAnMXDpdPreDpdCfrEnabled PreDpdCfrEnabled;
-            public RFmxSpecAnMXDpdPreDpdCfrMethod PreDpdCfrMethod;
-            public int PreDpdCfrMaxIterations;
-            public double PreDpdCfrTargetPapr_dB;
-            public RFmxSpecAnMXDpdPreDpdCfrWindowType PreDpdCfrWindowType;
-            public int PreDpdCfrWindowLength;
-            public double PreDpdCfrShapingFactor;
-            public double PreDpdCfrShapingThreshold_dB;
-            public RFmxSpecAnMXDpdPreDpdCfrFilterEnabled PreDpdCfrFilterEnabled;
-            public PreDpdCrestFactorReductionCarrierChannel[] PreDpdCfrCarrierChannels;
+            public RFmxSpecAnMXDpdPreDpdCfrEnabled Enabled;
+            public RFmxSpecAnMXDpdPreDpdCfrMethod Method;
+            public int MaxIterations;
+            public double TargetPapr_dB;
+            public RFmxSpecAnMXDpdPreDpdCfrWindowType WindowType;
+            public int WindowLength;
+            public double ShapingFactor;
+            public double ShapingThreshold_dB;
+            public RFmxSpecAnMXDpdPreDpdCfrFilterEnabled FilterEnabled;
+            public PreDpdCrestFactorReductionCarrierChannel[] CarrierChannels;
 
             public static PreDpdCrestFactorReduction GetDefault()
             {
                 return new PreDpdCrestFactorReduction
                 {
-                    PreDpdCfrEnabled = RFmxSpecAnMXDpdPreDpdCfrEnabled.False,
-                    PreDpdCfrMethod = RFmxSpecAnMXDpdPreDpdCfrMethod.Clipping,
-                    PreDpdCfrMaxIterations = 10,
-                    PreDpdCfrTargetPapr_dB = 8,
-                    PreDpdCfrWindowType = RFmxSpecAnMXDpdPreDpdCfrWindowType.KaiserBessel,
-                    PreDpdCfrWindowLength = 10,
-                    PreDpdCfrShapingFactor = 5,
-                    PreDpdCfrShapingThreshold_dB = -5,
-                    PreDpdCfrFilterEnabled = RFmxSpecAnMXDpdPreDpdCfrFilterEnabled.False,
-                    PreDpdCfrCarrierChannels = new PreDpdCrestFactorReductionCarrierChannel[] { PreDpdCrestFactorReductionCarrierChannel.GetDefault() }
+                    Enabled = RFmxSpecAnMXDpdPreDpdCfrEnabled.False,
+                    Method = RFmxSpecAnMXDpdPreDpdCfrMethod.Clipping,
+                    MaxIterations = 10,
+                    TargetPapr_dB = 8,
+                    WindowType = RFmxSpecAnMXDpdPreDpdCfrWindowType.KaiserBessel,
+                    WindowLength = 10,
+                    ShapingFactor = 5,
+                    ShapingThreshold_dB = -5,
+                    FilterEnabled = RFmxSpecAnMXDpdPreDpdCfrFilterEnabled.False,
+                    CarrierChannels = new PreDpdCrestFactorReductionCarrierChannel[] { PreDpdCrestFactorReductionCarrierChannel.GetDefault() }
                 };
             }
         }
@@ -71,29 +71,29 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         }
         public struct ApplyDpdCrestFactorReduction
         {
-            public RFmxSpecAnMXDpdApplyDpdCfrEnabled ApplyDpdCfrEnabled;
-            public RFmxSpecAnMXDpdApplyDpdCfrMethod ApplyDpdCfrMethod;
-            public int ApplyDpdCfrMaxIterations;
-            public RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType ApplyDpdCfrTargetPaprType;
-            public double ApplyDpdCfrTargetPapr_dB;
-            public RFmxSpecAnMXDpdApplyDpdCfrWindowType ApplyDpdCfrWindowType;
-            public int ApplyDpdCfrWindowLength;
-            public double ApplyDpdCfrShapingFactor;
-            public double ApplyDpdCfrShapingThreshold_dB;
+            public RFmxSpecAnMXDpdApplyDpdCfrEnabled Enabled;
+            public RFmxSpecAnMXDpdApplyDpdCfrMethod Method;
+            public int MaxIterations;
+            public RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType TargetPaprType;
+            public double TargetPapr_dB;
+            public RFmxSpecAnMXDpdApplyDpdCfrWindowType WindowType;
+            public int WindowLength;
+            public double ShapingFactor;
+            public double ShapingThreshold_dB;
 
             public static ApplyDpdCrestFactorReduction GetDefault()
             {
                 return new ApplyDpdCrestFactorReduction
                 {
-                    ApplyDpdCfrEnabled = RFmxSpecAnMXDpdApplyDpdCfrEnabled.True,
-                    ApplyDpdCfrMethod = RFmxSpecAnMXDpdApplyDpdCfrMethod.Clipping,
-                    ApplyDpdCfrMaxIterations = 10,
-                    ApplyDpdCfrTargetPaprType = RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType.InputPapr,
-                    ApplyDpdCfrTargetPapr_dB = 8,
-                    ApplyDpdCfrWindowType = RFmxSpecAnMXDpdApplyDpdCfrWindowType.KaiserBessel,
-                    ApplyDpdCfrWindowLength = 10,
-                    ApplyDpdCfrShapingFactor = 5,
-                    ApplyDpdCfrShapingThreshold_dB = -5,
+                    Enabled = RFmxSpecAnMXDpdApplyDpdCfrEnabled.True,
+                    Method = RFmxSpecAnMXDpdApplyDpdCfrMethod.Clipping,
+                    MaxIterations = 10,
+                    TargetPaprType = RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType.InputPapr,
+                    TargetPapr_dB = 8,
+                    WindowType = RFmxSpecAnMXDpdApplyDpdCfrWindowType.KaiserBessel,
+                    WindowLength = 10,
+                    ShapingFactor = 5,
+                    ShapingThreshold_dB = -5,
                 };
             }
         }
@@ -179,23 +179,23 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             //Configure Pre-DPD CFR             
             RFmxSpecAnMXDpdApplyDpdIdleDurationPresent preDpdCfrIdlePresent = preDpdCfrWaveform.IdleDurationPresent ?
                 RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
-            specAn.Dpd.PreDpd.SetCfrEnabled(selectorString, preDpdCfr.PreDpdCfrEnabled);
-            specAn.Dpd.PreDpd.SetCfrMethod(selectorString, preDpdCfr.PreDpdCfrMethod);
-            specAn.Dpd.PreDpd.SetCfrMaximumIterations(selectorString, preDpdCfr.PreDpdCfrMaxIterations);
-            specAn.Dpd.PreDpd.SetCfrTargetPapr(selectorString, preDpdCfr.PreDpdCfrTargetPapr_dB);
-            specAn.Dpd.PreDpd.SetCfrWindowType(selectorString, preDpdCfr.PreDpdCfrWindowType);
-            specAn.Dpd.PreDpd.SetCfrWindowLength(selectorString, preDpdCfr.PreDpdCfrWindowLength);
-            specAn.Dpd.PreDpd.SetCfrShapingFactor(selectorString, preDpdCfr.PreDpdCfrShapingFactor);
-            specAn.Dpd.PreDpd.SetCfrShapingThreshold(selectorString, preDpdCfr.PreDpdCfrShapingThreshold_dB);
-            specAn.Dpd.PreDpd.SetCfrFilterEnabled(selectorString, preDpdCfr.PreDpdCfrFilterEnabled);
-            specAn.Dpd.PreDpd.SetCfrNumberOfCarriers(selectorString, preDpdCfr.PreDpdCfrCarrierChannels.Length);
+            specAn.Dpd.PreDpd.SetCfrEnabled(selectorString, preDpdCfr.Enabled);
+            specAn.Dpd.PreDpd.SetCfrMethod(selectorString, preDpdCfr.Method);
+            specAn.Dpd.PreDpd.SetCfrMaximumIterations(selectorString, preDpdCfr.MaxIterations);
+            specAn.Dpd.PreDpd.SetCfrTargetPapr(selectorString, preDpdCfr.TargetPapr_dB);
+            specAn.Dpd.PreDpd.SetCfrWindowType(selectorString, preDpdCfr.WindowType);
+            specAn.Dpd.PreDpd.SetCfrWindowLength(selectorString, preDpdCfr.WindowLength);
+            specAn.Dpd.PreDpd.SetCfrShapingFactor(selectorString, preDpdCfr.ShapingFactor);
+            specAn.Dpd.PreDpd.SetCfrShapingThreshold(selectorString, preDpdCfr.ShapingThreshold_dB);
+            specAn.Dpd.PreDpd.SetCfrFilterEnabled(selectorString, preDpdCfr.FilterEnabled);
+            specAn.Dpd.PreDpd.SetCfrNumberOfCarriers(selectorString, preDpdCfr.CarrierChannels.Length);
 
             string carrierString;
-            for (int i = 0; i < preDpdCfr.PreDpdCfrCarrierChannels.Length; i++)
+            for (int i = 0; i < preDpdCfr.CarrierChannels.Length; i++)
             {
                 carrierString = RFmxSpecAnMX.BuildCarrierString2(selectorString, i);
-                specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.PreDpdCfrCarrierChannels[i].Offset);
-                specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.PreDpdCfrCarrierChannels[i].Bandwidth);
+                specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.CarrierChannels[i].Offset);
+                specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.CarrierChannels[i].Bandwidth);
             }
 
             // Apply CFR and return
@@ -215,15 +215,15 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         }
         public static void ConfigureApplyDpdCrestFactorReduction(RFmxSpecAnMX specAn, ApplyDpdCrestFactorReduction applyDpdCfr, string selectorString = "")
         {
-            specAn.Dpd.ApplyDpd.SetCfrEnabled(selectorString, applyDpdCfr.ApplyDpdCfrEnabled);
-            specAn.Dpd.ApplyDpd.SetCfrMethod(selectorString, applyDpdCfr.ApplyDpdCfrMethod);
-            specAn.Dpd.ApplyDpd.SetCfrMaximumIterations(selectorString, applyDpdCfr.ApplyDpdCfrMaxIterations);
-            specAn.Dpd.ApplyDpd.SetCfrTargetPaprType(selectorString, applyDpdCfr.ApplyDpdCfrTargetPaprType);
-            specAn.Dpd.ApplyDpd.SetCfrTargetPapr(selectorString, applyDpdCfr.ApplyDpdCfrTargetPapr_dB);
-            specAn.Dpd.ApplyDpd.SetCfrWindowType(selectorString, applyDpdCfr.ApplyDpdCfrWindowType);
-            specAn.Dpd.ApplyDpd.SetCfrWindowLength(selectorString, applyDpdCfr.ApplyDpdCfrWindowLength);
-            specAn.Dpd.ApplyDpd.SetCfrShapingFactor(selectorString, applyDpdCfr.ApplyDpdCfrShapingFactor);
-            specAn.Dpd.ApplyDpd.SetCfrShapingThreshold(selectorString, applyDpdCfr.ApplyDpdCfrShapingThreshold_dB);
+            specAn.Dpd.ApplyDpd.SetCfrEnabled(selectorString, applyDpdCfr.Enabled);
+            specAn.Dpd.ApplyDpd.SetCfrMethod(selectorString, applyDpdCfr.Method);
+            specAn.Dpd.ApplyDpd.SetCfrMaximumIterations(selectorString, applyDpdCfr.MaxIterations);
+            specAn.Dpd.ApplyDpd.SetCfrTargetPaprType(selectorString, applyDpdCfr.TargetPaprType);
+            specAn.Dpd.ApplyDpd.SetCfrTargetPapr(selectorString, applyDpdCfr.TargetPapr_dB);
+            specAn.Dpd.ApplyDpd.SetCfrWindowType(selectorString, applyDpdCfr.WindowType);
+            specAn.Dpd.ApplyDpd.SetCfrWindowLength(selectorString, applyDpdCfr.WindowLength);
+            specAn.Dpd.ApplyDpd.SetCfrShapingFactor(selectorString, applyDpdCfr.ShapingFactor);
+            specAn.Dpd.ApplyDpd.SetCfrShapingThreshold(selectorString, applyDpdCfr.ShapingThreshold_dB);
         }
 
         public static void ConfigureLookupTable(RFmxSpecAnMX specAn, LookupTableConfiguration lutConfig, string selectorString = "")

--- a/Source/Methods/RFmxDPD/RFmxDPD.cs
+++ b/Source/Methods/RFmxDPD/RFmxDPD.cs
@@ -9,15 +9,15 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         #region Type Definitionss
         public struct PreDpdCrestFactorReductionCarrierChannel
         {
-            public double Offset;
-            public double Bandwidth;
+            public double Offset_Hz;
+            public double Bandwidth_Hz;
 
             public static PreDpdCrestFactorReductionCarrierChannel GetDefault()
             {
                 return new PreDpdCrestFactorReductionCarrierChannel
                 {
-                    Offset = 0.000,
-                    Bandwidth = 20e6
+                    Offset_Hz = 0.000,
+                    Bandwidth_Hz = 20e6
                 };
             }
         }
@@ -194,8 +194,8 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             for (int i = 0; i < preDpdCfr.CarrierChannels.Length; i++)
             {
                 carrierString = RFmxSpecAnMX.BuildCarrierString2(selectorString, i);
-                specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.CarrierChannels[i].Offset);
-                specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.CarrierChannels[i].Bandwidth);
+                specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.CarrierChannels[i].Offset_Hz);
+                specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.CarrierChannels[i].Bandwidth_Hz);
             }
 
             // Apply CFR and return

--- a/Source/Methods/RFmxDPD/RFmxDPD.cs
+++ b/Source/Methods/RFmxDPD/RFmxDPD.cs
@@ -7,25 +7,20 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
     public static class RFmxDPD
     {
         #region Type Definitionss
-        public struct CommonConfiguration
+        public struct PreDpdCrestFactorReductionCarrierChannel
         {
-            public double MeasurementInterval_s;
-            public RFmxSpecAnMXDpdSignalType SignalType;
-            public RFmxSpecAnMXDpdSynchronizationMethod SynchronizationMethod;
-            public double DutAverageInputPower_dBm;
+            public double Offset;
+            public double Bandwidth;
 
-            public static CommonConfiguration GetDefault()
+            public static PreDpdCrestFactorReductionCarrierChannel GetDefault()
             {
-                return new CommonConfiguration
+                return new PreDpdCrestFactorReductionCarrierChannel
                 {
-                    MeasurementInterval_s = 100e-6,
-                    SignalType = RFmxSpecAnMXDpdSignalType.Modulated,
-                    DutAverageInputPower_dBm = -20.0,
-                    SynchronizationMethod = RFmxSpecAnMXDpdSynchronizationMethod.Direct
+                    Offset = 0.000,
+                    Bandwidth = 20e6
                 };
             }
         }
-
         public struct PreDpdCrestFactorReduction
         {
             public RFmxSpecAnMXDpdPreDpdCfrEnabled PreDpdCfrEnabled;
@@ -56,48 +51,52 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
                 };
             }
         }
-        public struct PreDpdCrestFactorReductionCarrierChannel
+        public struct CommonConfiguration
         {
-            public double Offset;
-            public double Bandwidth;
+            public double MeasurementInterval_s;
+            public RFmxSpecAnMXDpdSignalType SignalType;
+            public RFmxSpecAnMXDpdSynchronizationMethod SynchronizationMethod;
+            public double DutAverageInputPower_dBm;
 
-            public static PreDpdCrestFactorReductionCarrierChannel GetDefault()
+            public static CommonConfiguration GetDefault()
             {
-                return new PreDpdCrestFactorReductionCarrierChannel
+                return new CommonConfiguration
                 {
-                    Offset = 0.000,
-                    Bandwidth = 20e6
+                    MeasurementInterval_s = 100e-6,
+                    SignalType = RFmxSpecAnMXDpdSignalType.Modulated,
+                    DutAverageInputPower_dBm = -20.0,
+                    SynchronizationMethod = RFmxSpecAnMXDpdSynchronizationMethod.Direct
                 };
             }
+        }
+        public struct ApplyDpdCrestFactorReduction
+        {
+            public RFmxSpecAnMXDpdApplyDpdCfrEnabled ApplyDpdCfrEnabled;
+            public RFmxSpecAnMXDpdApplyDpdCfrMethod ApplyDpdCfrMethod;
+            public int ApplyDpdCfrMaxIterations;
+            public RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType ApplyDpdCfrTargetPaprType;
+            public double ApplyDpdCfrTargetPapr_dB;
+            public RFmxSpecAnMXDpdApplyDpdCfrWindowType ApplyDpdCfrWindowType;
+            public int ApplyDpdCfrWindowLength;
+            public double ApplyDpdCfrShapingFactor;
+            public double ApplyDpdCfrShapingThreshold_dB;
 
-            public struct ApplyDpdCrestFactorReduction
+            public static ApplyDpdCrestFactorReduction GetDefault()
             {
-                public RFmxSpecAnMXDpdApplyDpdCfrEnabled ApplyDpdCfrEnabled;
-                public RFmxSpecAnMXDpdApplyDpdCfrMethod ApplyDpdCfrMethod;
-                public int ApplyDpdCfrMaxIterations;
-                public RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType ApplyDpdCfrTargetPaprType;
-                public double ApplyDpdCfrTargetPapr_dB;
-                public RFmxSpecAnMXDpdApplyDpdCfrWindowType ApplyDpdCfrWindowType;
-                public int ApplyDpdCfrWindowLength;
-                public double ApplyDpdCfrShapingFactor;
-                public double ApplyDpdCfrShapingThreshold_dB;
-
-                public static ApplyDpdCrestFactorReduction GetDefault()
+                return new ApplyDpdCrestFactorReduction
                 {
-                    return new ApplyDpdCrestFactorReduction
-                    {
-                        ApplyDpdCfrEnabled = RFmxSpecAnMXDpdApplyDpdCfrEnabled.False,
-                        ApplyDpdCfrMethod = RFmxSpecAnMXDpdApplyDpdCfrMethod.Clipping,
-                        ApplyDpdCfrMaxIterations = 10,
-                        ApplyDpdCfrTargetPaprType = RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType.InputPapr,
-                        ApplyDpdCfrTargetPapr_dB = 8,
-                        ApplyDpdCfrWindowType = RFmxSpecAnMXDpdApplyDpdCfrWindowType.KaiserBessel,
-                        ApplyDpdCfrWindowLength = 10,
-                        ApplyDpdCfrShapingFactor = 5,
-                        ApplyDpdCfrShapingThreshold_dB = -5,
-                    };
-                }
+                    ApplyDpdCfrEnabled = RFmxSpecAnMXDpdApplyDpdCfrEnabled.True,
+                    ApplyDpdCfrMethod = RFmxSpecAnMXDpdApplyDpdCfrMethod.Clipping,
+                    ApplyDpdCfrMaxIterations = 10,
+                    ApplyDpdCfrTargetPaprType = RFmxSpecAnMXDpdApplyDpdCfrTargetPaprType.InputPapr,
+                    ApplyDpdCfrTargetPapr_dB = 8,
+                    ApplyDpdCfrWindowType = RFmxSpecAnMXDpdApplyDpdCfrWindowType.KaiserBessel,
+                    ApplyDpdCfrWindowLength = 10,
+                    ApplyDpdCfrShapingFactor = 5,
+                    ApplyDpdCfrShapingThreshold_dB = -5,
+                };
             }
+        }
         public struct LookupTableConfiguration
         {
             public RFmxSpecAnMXDpdLookupTableType Type;
@@ -169,53 +168,62 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         #endregion
 
         #region ConfigureDPD
-            public static Waveform ConfigureCommon(RFmxSpecAnMX specAn, CommonConfiguration commonConfig, PreDpdCrestFactorReduction preDpdCfr, ApplyDpdCrestFactorReduction applyDpdCfr, Waveform referenceWaveform, string selectorString = "")
+        public static Waveform ConfigurePreDPDCrestFactorReduction(RFmxSpecAnMX specAn, Waveform referenceWaveform, PreDpdCrestFactorReduction preDpdCfr, string selectorString = "")
         {
-                Waveform preDpdCfrWaveform = new Waveform();
-                preDpdCfrWaveform = referenceWaveform;
-            RFmxSpecAnMXDpdReferenceWaveformIdleDurationPresent idlePresent = referenceWaveform.IdleDurationPresent ? RFmxSpecAnMXDpdReferenceWaveformIdleDurationPresent.True : RFmxSpecAnMXDpdReferenceWaveformIdleDurationPresent.False;
-                RFmxSpecAnMXDpdApplyDpdIdleDurationPresent preDpdCfrIdlePresent = referenceWaveform.IdleDurationPresent ? RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
+            // Configure the new waveform
+            Waveform preDpdCfrWaveform = referenceWaveform;
+            preDpdCfrWaveform.Name = referenceWaveform.Name + "preDPDCFR";
+            preDpdCfrWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
+            preDpdCfrWaveform.Script = preDpdCfrWaveform.Script?.Replace(referenceWaveform.Name, preDpdCfrWaveform.Name);
+
+            //Configure Pre-DPD CFR             
+            RFmxSpecAnMXDpdApplyDpdIdleDurationPresent preDpdCfrIdlePresent = preDpdCfrWaveform.IdleDurationPresent ?
+                RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
+            specAn.Dpd.PreDpd.SetCfrEnabled(selectorString, preDpdCfr.PreDpdCfrEnabled);
+            specAn.Dpd.PreDpd.SetCfrMethod(selectorString, preDpdCfr.PreDpdCfrMethod);
+            specAn.Dpd.PreDpd.SetCfrMaximumIterations(selectorString, preDpdCfr.PreDpdCfrMaxIterations);
+            specAn.Dpd.PreDpd.SetCfrTargetPapr(selectorString, preDpdCfr.PreDpdCfrTargetPapr_dB);
+            specAn.Dpd.PreDpd.SetCfrWindowType(selectorString, preDpdCfr.PreDpdCfrWindowType);
+            specAn.Dpd.PreDpd.SetCfrWindowLength(selectorString, preDpdCfr.PreDpdCfrWindowLength);
+            specAn.Dpd.PreDpd.SetCfrShapingFactor(selectorString, preDpdCfr.PreDpdCfrShapingFactor);
+            specAn.Dpd.PreDpd.SetCfrShapingThreshold(selectorString, preDpdCfr.PreDpdCfrShapingThreshold_dB);
+            specAn.Dpd.PreDpd.SetCfrFilterEnabled(selectorString, preDpdCfr.PreDpdCfrFilterEnabled);
+            specAn.Dpd.PreDpd.SetCfrNumberOfCarriers(selectorString, preDpdCfr.PreDpdCfrCarrierChannels.Length);
+
+            string carrierString;
+            for (int i = 0; i < preDpdCfr.PreDpdCfrCarrierChannels.Length; i++)
+            {
+                carrierString = RFmxSpecAnMX.BuildCarrierString2(selectorString, i);
+                specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.PreDpdCfrCarrierChannels[i].Offset);
+                specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.PreDpdCfrCarrierChannels[i].Bandwidth);
+            }
+
+            // Apply CFR and return
+            specAn.Dpd.PreDpd.ApplyPreDpdSignalConditioning(selectorString, referenceWaveform.Data, preDpdCfrIdlePresent, ref preDpdCfrWaveform.Data, out preDpdCfrWaveform.PAPR_dB);
+            return preDpdCfrWaveform;
+        }
+        public static void ConfigureCommon(RFmxSpecAnMX specAn, CommonConfiguration commonConfig, Waveform referenceWaveform, string selectorString = "")
+        {
+            RFmxSpecAnMXDpdReferenceWaveformIdleDurationPresent idlePresent = referenceWaveform.IdleDurationPresent ?
+                RFmxSpecAnMXDpdReferenceWaveformIdleDurationPresent.True : RFmxSpecAnMXDpdReferenceWaveformIdleDurationPresent.False;
             specAn.SelectMeasurements(selectorString, RFmxSpecAnMXMeasurementTypes.Dpd, true);
             specAn.Dpd.Configuration.ConfigureReferenceWaveform(selectorString, referenceWaveform.Data, idlePresent, commonConfig.SignalType);
             specAn.Dpd.Configuration.ConfigureDutAverageInputPower(selectorString, commonConfig.DutAverageInputPower_dBm);
             specAn.Dpd.Configuration.ConfigureMeasurementInterval(selectorString, commonConfig.MeasurementInterval_s);
             specAn.Dpd.Configuration.ConfigureMeasurementSampleRate(selectorString, RFmxSpecAnMXDpdMeasurementSampleRateMode.ReferenceWaveform, referenceWaveform.SampleRate);
-            specAn.Dpd.Configuration.ConfigureSynchronizationMethod(selectorString, commonConfig.SynchronizationMethod);           
-
-                //Pre DPD CFR             
-                specAn.Dpd.PreDpd.SetCfrEnabled("", preDpdCfr.PreDpdCfrEnabled);
-                specAn.Dpd.PreDpd.SetCfrMethod("", preDpdCfr.PreDpdCfrMethod);
-                specAn.Dpd.PreDpd.SetCfrMaximumIterations("", preDpdCfr.PreDpdCfrMaxIterations);
-                specAn.Dpd.PreDpd.SetCfrTargetPapr("", preDpdCfr.PreDpdCfrTargetPapr_dB);
-                specAn.Dpd.PreDpd.SetCfrWindowType("", preDpdCfr.PreDpdCfrWindowType);
-                specAn.Dpd.PreDpd.SetCfrWindowLength("", preDpdCfr.PreDpdCfrWindowLength);
-                specAn.Dpd.PreDpd.SetCfrShapingFactor("", preDpdCfr.PreDpdCfrShapingFactor);
-                specAn.Dpd.PreDpd.SetCfrShapingThreshold("", preDpdCfr.PreDpdCfrShapingThreshold_dB);
-                specAn.Dpd.PreDpd.SetCfrFilterEnabled("", preDpdCfr.PreDpdCfrFilterEnabled);
-                specAn.Dpd.PreDpd.SetCfrNumberOfCarriers("", preDpdCfr.PreDpdCfrCarrierChannels.Length);
-
-                string carrierString;
-                for (int i = 0; i < preDpdCfr.PreDpdCfrCarrierChannels.Length; i++)
-                {
-                    carrierString = RFmxSpecAnMX.BuildCarrierString2("", i);
-                    specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.PreDpdCfrCarrierChannels[i].Offset);
-                    specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.PreDpdCfrCarrierChannels[i].Bandwidth);
-                }
-                specAn.Dpd.PreDpd.ApplyPreDpdSignalConditioning("", referenceWaveform.Data, preDpdCfrIdlePresent, ref preDpdCfrWaveform.Data, out preDpdCfrWaveform.PAPR_dB);
-               
-                //Apply DPD CFR              
-                specAn.Dpd.ApplyDpd.SetCfrEnabled("", applyDpdCfr.ApplyDpdCfrEnabled);
-                specAn.Dpd.ApplyDpd.SetCfrMethod("", applyDpdCfr.ApplyDpdCfrMethod);
-                specAn.Dpd.ApplyDpd.SetCfrMaximumIterations("", applyDpdCfr.ApplyDpdCfrMaxIterations);
-                specAn.Dpd.ApplyDpd.SetCfrTargetPaprType("", applyDpdCfr.ApplyDpdCfrTargetPaprType);
-                specAn.Dpd.ApplyDpd.SetCfrTargetPapr("", applyDpdCfr.ApplyDpdCfrTargetPapr_dB);
-                specAn.Dpd.ApplyDpd.SetCfrWindowType("", applyDpdCfr.ApplyDpdCfrWindowType);
-                specAn.Dpd.ApplyDpd.SetCfrWindowLength("", applyDpdCfr.ApplyDpdCfrWindowLength);
-                specAn.Dpd.ApplyDpd.SetCfrShapingFactor("", applyDpdCfr.ApplyDpdCfrShapingFactor);
-                specAn.Dpd.ApplyDpd.SetCfrShapingThreshold("", applyDpdCfr.ApplyDpdCfrShapingThreshold_dB);
-                
-                return preDpdCfrWaveform;
-
+            specAn.Dpd.Configuration.ConfigureSynchronizationMethod(selectorString, commonConfig.SynchronizationMethod);
+        }
+        public static void ConfigureApplyDpdCrestFactorReduction(RFmxSpecAnMX specAn, ApplyDpdCrestFactorReduction applyDpdCfr, string selectorString = "")
+        {
+            specAn.Dpd.ApplyDpd.SetCfrEnabled(selectorString, applyDpdCfr.ApplyDpdCfrEnabled);
+            specAn.Dpd.ApplyDpd.SetCfrMethod(selectorString, applyDpdCfr.ApplyDpdCfrMethod);
+            specAn.Dpd.ApplyDpd.SetCfrMaximumIterations(selectorString, applyDpdCfr.ApplyDpdCfrMaxIterations);
+            specAn.Dpd.ApplyDpd.SetCfrTargetPaprType(selectorString, applyDpdCfr.ApplyDpdCfrTargetPaprType);
+            specAn.Dpd.ApplyDpd.SetCfrTargetPapr(selectorString, applyDpdCfr.ApplyDpdCfrTargetPapr_dB);
+            specAn.Dpd.ApplyDpd.SetCfrWindowType(selectorString, applyDpdCfr.ApplyDpdCfrWindowType);
+            specAn.Dpd.ApplyDpd.SetCfrWindowLength(selectorString, applyDpdCfr.ApplyDpdCfrWindowLength);
+            specAn.Dpd.ApplyDpd.SetCfrShapingFactor(selectorString, applyDpdCfr.ApplyDpdCfrShapingFactor);
+            specAn.Dpd.ApplyDpd.SetCfrShapingThreshold(selectorString, applyDpdCfr.ApplyDpdCfrShapingThreshold_dB);
         }
 
         public static void ConfigureLookupTable(RFmxSpecAnMX specAn, LookupTableConfiguration lutConfig, string selectorString = "")
@@ -250,15 +258,15 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             lutResults.PredistortedWaveform.Name = referenceWaveform.Name + "postLutDpd";
             lutResults.PredistortedWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
             lutResults.PredistortedWaveform.Script = lutResults.PredistortedWaveform.Script?.Replace(referenceWaveform.Name, lutResults.PredistortedWaveform.Name);
-            
+
             RfsgGenerationStatus preDpdGenerationStatus = rfsgSession.CheckGenerationStatus();
             if (preDpdGenerationStatus == RfsgGenerationStatus.Complete)
                 rfsgSession.Initiate(); // initiate if not already generating
-            
+
             specAn.Initiate(selectorString, "");
             RFmxSpecAnMXDpdApplyDpdIdleDurationPresent idlePresent = referenceWaveform.IdleDurationPresent ? RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
             specAn.WaitForMeasurementComplete(selectorString, 10.0); // wait for LUT creation to finish
-            //waveform data and PAPR are overwritten in post DPD waveform
+                                                                     //waveform data and PAPR are overwritten in post DPD waveform
             specAn.Dpd.ApplyDpd.ApplyDigitalPredistortion(selectorString, referenceWaveform.Data, idlePresent, 10.0, ref lutResults.PredistortedWaveform.Data,
                 out lutResults.PowerResults.WaveformTruePapr_dB, out lutResults.PowerResults.WaveformPowerOffset_dB);
 
@@ -269,14 +277,14 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             ApplyWaveformAttributes(rfsgSession, lutResults.PredistortedWaveform);
             lutResults.PowerResults.TrainingPower_dBm = rfsgSession.RF.PowerLevel;
             specAn.Dpd.Results.FetchLookupTable(selectorString, 10.0, ref lutResults.InputPowers_dBm, ref lutResults.ComplexGains_dB);
-            
+
             if (preDpdGenerationStatus == RfsgGenerationStatus.InProgress)
                 rfsgSession.Initiate(); // restart generation if it was running on function call
 
             return lutResults;
         }
 
-        public static MemoryPolynomialResults PerformMemoryPolynomial(RFmxSpecAnMX specAn, NIRfsg rfsgSession, MemoryPolynomialConfiguration mpConfig, 
+        public static MemoryPolynomialResults PerformMemoryPolynomial(RFmxSpecAnMX specAn, NIRfsg rfsgSession, MemoryPolynomialConfiguration mpConfig,
             Waveform referenceWaveform, string selectorString = "")
         {
             //Instantiate new waveform with reference waveform properties
@@ -287,7 +295,7 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
             mpResults.PredistortedWaveform.Name = referenceWaveform.Name + "postMpDpd";
             mpResults.PredistortedWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
             mpResults.PredistortedWaveform.Script = mpResults.PredistortedWaveform.Script?.Replace(referenceWaveform.Name, mpResults.PredistortedWaveform.Name);
-            
+
             RFmxSpecAnMXDpdApplyDpdIdleDurationPresent idlePresent = referenceWaveform.IdleDurationPresent ? RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
 
             RfsgGenerationStatus preDpdGenerationStatus = rfsgSession.CheckGenerationStatus();
@@ -299,7 +307,7 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
                 rfsgSession.Initiate();
                 specAn.Initiate(selectorString, "");
                 specAn.WaitForMeasurementComplete(selectorString, 10.0); // wait for polynomial coefficients to be calculated
-                //waveform data and PAPR are overwritten in post DPD waveform
+                                                                         //waveform data and PAPR are overwritten in post DPD waveform
                 specAn.Dpd.ApplyDpd.ApplyDigitalPredistortion(selectorString, referenceWaveform.Data, idlePresent, 10.0, ref mpResults.PredistortedWaveform.Data,
                     out mpResults.PowerResults.WaveformTruePapr_dB, out mpResults.PowerResults.WaveformPowerOffset_dB);
                 //Waveform's PAPR is modified to adjust the output power of the waveform on a per waveform basis rather than changing the
@@ -319,5 +327,3 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         #endregion
     }
 }
-}
-

--- a/Source/Methods/RFmxDPD/RFmxDPD.cs
+++ b/Source/Methods/RFmxDPD/RFmxDPD.cs
@@ -170,35 +170,41 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         #region ConfigureDPD
         public static Waveform ConfigurePreDPDCrestFactorReduction(RFmxSpecAnMX specAn, Waveform referenceWaveform, PreDpdCrestFactorReduction preDpdCfr, string selectorString = "")
         {
-            // Configure the new waveform
             Waveform preDpdCfrWaveform = referenceWaveform;
-            preDpdCfrWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
-            preDpdCfrWaveform.UpdateWaveformNameAndScript(referenceWaveform.Name + "preDPDCFR");
-
-            //Configure Pre-DPD CFR             
-            RFmxSpecAnMXDpdApplyDpdIdleDurationPresent preDpdCfrIdlePresent = preDpdCfrWaveform.IdleDurationPresent ?
-                RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
-            specAn.Dpd.PreDpd.SetCfrEnabled(selectorString, preDpdCfr.Enabled);
-            specAn.Dpd.PreDpd.SetCfrMethod(selectorString, preDpdCfr.Method);
-            specAn.Dpd.PreDpd.SetCfrMaximumIterations(selectorString, preDpdCfr.MaxIterations);
-            specAn.Dpd.PreDpd.SetCfrTargetPapr(selectorString, preDpdCfr.TargetPapr_dB);
-            specAn.Dpd.PreDpd.SetCfrWindowType(selectorString, preDpdCfr.WindowType);
-            specAn.Dpd.PreDpd.SetCfrWindowLength(selectorString, preDpdCfr.WindowLength);
-            specAn.Dpd.PreDpd.SetCfrShapingFactor(selectorString, preDpdCfr.ShapingFactor);
-            specAn.Dpd.PreDpd.SetCfrShapingThreshold(selectorString, preDpdCfr.ShapingThreshold_dB);
-            specAn.Dpd.PreDpd.SetCfrFilterEnabled(selectorString, preDpdCfr.FilterEnabled);
-            specAn.Dpd.PreDpd.SetCfrNumberOfCarriers(selectorString, preDpdCfr.CarrierChannels.Length);
-
-            string carrierString;
-            for (int i = 0; i < preDpdCfr.CarrierChannels.Length; i++)
+            if (preDpdCfr.Enabled == RFmxSpecAnMXDpdPreDpdCfrEnabled.True)
             {
-                carrierString = RFmxSpecAnMX.BuildCarrierString2(selectorString, i);
-                specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.CarrierChannels[i].Offset_Hz);
-                specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.CarrierChannels[i].Bandwidth_Hz);
-            }
+                // Configure the new waveform
+                preDpdCfrWaveform.Data = referenceWaveform.Data.Clone(); // clone waveform so RFmx can't act on reference waveform
+                preDpdCfrWaveform.UpdateWaveformNameAndScript(referenceWaveform.Name + "preDPDCFR");
 
-            // Apply CFR and return
-            specAn.Dpd.PreDpd.ApplyPreDpdSignalConditioning(selectorString, referenceWaveform.Data, preDpdCfrIdlePresent, ref preDpdCfrWaveform.Data, out preDpdCfrWaveform.PAPR_dB);
+                //Configure Pre-DPD CFR             
+                RFmxSpecAnMXDpdApplyDpdIdleDurationPresent preDpdCfrIdlePresent = preDpdCfrWaveform.IdleDurationPresent ?
+                    RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.True : RFmxSpecAnMXDpdApplyDpdIdleDurationPresent.False;
+                specAn.Dpd.PreDpd.SetCfrEnabled(selectorString, preDpdCfr.Enabled);
+                specAn.Dpd.PreDpd.SetCfrMethod(selectorString, preDpdCfr.Method);
+                specAn.Dpd.PreDpd.SetCfrMaximumIterations(selectorString, preDpdCfr.MaxIterations);
+                specAn.Dpd.PreDpd.SetCfrTargetPapr(selectorString, preDpdCfr.TargetPapr_dB);
+                specAn.Dpd.PreDpd.SetCfrWindowType(selectorString, preDpdCfr.WindowType);
+                specAn.Dpd.PreDpd.SetCfrWindowLength(selectorString, preDpdCfr.WindowLength);
+                specAn.Dpd.PreDpd.SetCfrShapingFactor(selectorString, preDpdCfr.ShapingFactor);
+                specAn.Dpd.PreDpd.SetCfrShapingThreshold(selectorString, preDpdCfr.ShapingThreshold_dB);
+                specAn.Dpd.PreDpd.SetCfrFilterEnabled(selectorString, preDpdCfr.FilterEnabled);
+                specAn.Dpd.PreDpd.SetCfrNumberOfCarriers(selectorString, preDpdCfr.CarrierChannels.Length);
+
+                string carrierString;
+                for (int i = 0; i < preDpdCfr.CarrierChannels.Length; i++)
+                {
+                    carrierString = RFmxSpecAnMX.BuildCarrierString2(selectorString, i);
+                    specAn.Dpd.PreDpd.SetCarrierOffset(carrierString, preDpdCfr.CarrierChannels[i].Offset_Hz);
+                    specAn.Dpd.PreDpd.SetCarrierBandwidth(carrierString, preDpdCfr.CarrierChannels[i].Bandwidth_Hz);
+                }
+
+                // Apply CFR and return
+                specAn.Dpd.PreDpd.ApplyPreDpdSignalConditioning(selectorString, referenceWaveform.Data, preDpdCfrIdlePresent, ref preDpdCfrWaveform.Data, out preDpdCfrWaveform.PAPR_dB);
+            }
+            else
+                specAn.Dpd.PreDpd.SetCfrEnabled(selectorString, preDpdCfr.Enabled);
+
             return preDpdCfrWaveform;
         }
         public static void ConfigureCommon(RFmxSpecAnMX specAn, CommonConfiguration commonConfig, Waveform referenceWaveform, string selectorString = "")
@@ -214,15 +220,20 @@ namespace NationalInstruments.ReferenceDesignLibraries.Methods
         }
         public static void ConfigureApplyDpdCrestFactorReduction(RFmxSpecAnMX specAn, ApplyDpdCrestFactorReduction applyDpdCfr, string selectorString = "")
         {
-            specAn.Dpd.ApplyDpd.SetCfrEnabled(selectorString, applyDpdCfr.Enabled);
-            specAn.Dpd.ApplyDpd.SetCfrMethod(selectorString, applyDpdCfr.Method);
-            specAn.Dpd.ApplyDpd.SetCfrMaximumIterations(selectorString, applyDpdCfr.MaxIterations);
-            specAn.Dpd.ApplyDpd.SetCfrTargetPaprType(selectorString, applyDpdCfr.TargetPaprType);
-            specAn.Dpd.ApplyDpd.SetCfrTargetPapr(selectorString, applyDpdCfr.TargetPapr_dB);
-            specAn.Dpd.ApplyDpd.SetCfrWindowType(selectorString, applyDpdCfr.WindowType);
-            specAn.Dpd.ApplyDpd.SetCfrWindowLength(selectorString, applyDpdCfr.WindowLength);
-            specAn.Dpd.ApplyDpd.SetCfrShapingFactor(selectorString, applyDpdCfr.ShapingFactor);
-            specAn.Dpd.ApplyDpd.SetCfrShapingThreshold(selectorString, applyDpdCfr.ShapingThreshold_dB);
+            if (applyDpdCfr.Enabled == RFmxSpecAnMXDpdApplyDpdCfrEnabled.True)
+            {
+                specAn.Dpd.ApplyDpd.SetCfrEnabled(selectorString, applyDpdCfr.Enabled);
+                specAn.Dpd.ApplyDpd.SetCfrMethod(selectorString, applyDpdCfr.Method);
+                specAn.Dpd.ApplyDpd.SetCfrMaximumIterations(selectorString, applyDpdCfr.MaxIterations);
+                specAn.Dpd.ApplyDpd.SetCfrTargetPaprType(selectorString, applyDpdCfr.TargetPaprType);
+                specAn.Dpd.ApplyDpd.SetCfrTargetPapr(selectorString, applyDpdCfr.TargetPapr_dB);
+                specAn.Dpd.ApplyDpd.SetCfrWindowType(selectorString, applyDpdCfr.WindowType);
+                specAn.Dpd.ApplyDpd.SetCfrWindowLength(selectorString, applyDpdCfr.WindowLength);
+                specAn.Dpd.ApplyDpd.SetCfrShapingFactor(selectorString, applyDpdCfr.ShapingFactor);
+                specAn.Dpd.ApplyDpd.SetCfrShapingThreshold(selectorString, applyDpdCfr.ShapingThreshold_dB);
+            }
+            else
+                specAn.Dpd.ApplyDpd.SetCfrEnabled(selectorString, applyDpdCfr.Enabled);
         }
 
         public static void ConfigureLookupTable(RFmxSpecAnMX specAn, LookupTableConfiguration lutConfig, string selectorString = "")


### PR DESCRIPTION
Based off of @cindyxie's work, I've rebased the CFR changes on the latest master branch. 

I've moved both CFR functions to standalone functions within the DPD module. The rationale for this is that these are optional use cases and not required; having them all in one function reduces overall function calls, but dramatically expands the required inputs for the functions when they may or may not be used. Additionally, since the pre-DPD waveform is used for the new reference waveform I think it is better to configure it separately, then pass the waveform into the Configure Common. I'm not so sure about Apply DPD CFR; that theoretically could still live in the Common function. However, two reasons prevent me from doing so:
1) It's still an optional use case
2) It's more work to update the examples this way

Finally, one point I would like to decide on is would `PostDpdCfr` be a clearer name than `ApplyDpdCfr`? I am aware that this would diverge from the RFmx nomenclature, but it just seems rather unclear.