### PR TITLE
Project file corrections for SG and WLAN simple example

### DIFF
--- a/Examples/SG_Example/SG_Example.csproj
+++ b/Examples/SG_Example/SG_Example.csproj
@@ -33,6 +33,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>NationalInstruments.ReferenceDesignLibraries.Examples.SGExample</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="NationalInstruments.ModularInstruments.NIRfsg.Fx45, Version=18.2.0.49152, Culture=neutral, PublicKeyToken=4febd62461bf11a4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Examples/SG_Example/SG_Example.sln
+++ b/Examples/SG_Example/SG_Example.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29025.244
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SG_Example", "SG_Example.csproj", "{AB4D3711-2492-4ADF-AEC6-6F9C159BB835}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Project Dependencies", "Project Dependencies", "{DDBEE65B-51DB-4908-A5A4-B1A134DDF93F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SG", "..\..\Source\SG\SG.csproj", "{89ABCAC5-CEDB-4535-BD58-E205A97834D9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\..\Source\Common\Common.csproj", "{8E7D5092-B685-4AD3-9DA3-7C53E56F0F32}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SG_Example", "SG_Example.csproj", "{AB4D3711-2492-4ADF-AEC6-6F9C159BB835}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Examples/WLAN_Example/WLAN_Example.csproj
+++ b/Examples/WLAN_Example/WLAN_Example.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{DA114941-68DF-472C-A7D8-FDEF0412A4C1}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>Examples</RootNamespace>
-    <AssemblyName>LTE Example</AssemblyName>
+    <AssemblyName>WLAN_Example</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
@@ -35,6 +35,9 @@
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>NationalInstruments.ReferenceDesignLibraries.Examples.Program</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="NationalInstruments.RFmx.InstrMX.Fx40, Version=19.0.0.49152, Culture=neutral, PublicKeyToken=dc6ad606294fc298, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -54,7 +57,6 @@
     <ProjectReference Include="..\..\Source\Common\Common.csproj">
       <Project>{8e7d5092-b685-4ad3-9da3-7c53e56f0f32}</Project>
       <Name>Common</Name>
-      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\Source\SA\RFmx Instr\RFmxInstr.csproj">
       <Project>{ab49d5a9-9585-445a-ae8a-e4dd2b8956aa}</Project>

--- a/Examples/WLAN_Example/WLAN_Example.sln
+++ b/Examples/WLAN_Example/WLAN_Example.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29230.47
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RFmxWLAN", "..\..\Source\SA\RFmx WLAN\RFmxWLAN.csproj", "{9E8F4D28-AC1D-4A06-8C62-FC96097890B9}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WLAN_Example", "WLAN_Example.csproj", "{DA114941-68DF-472C-A7D8-FDEF0412A4C1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RFmxInstr", "..\..\Source\SA\RFmx Instr\RFmxInstr.csproj", "{AB49D5A9-9585-445A-AE8A-E4DD2B8956AA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\..\Source\Common\Common.csproj", "{8E7D5092-B685-4AD3-9DA3-7C53E56F0F32}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RFmxWLAN", "..\..\Source\SA\RFmx WLAN\RFmxWLAN.csproj", "{9E8F4D28-AC1D-4A06-8C62-FC96097890B9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
CHANGE: SG project set the simple example as start up project
CHANGE: WLAN project re-added RDL common as reference, because common DLL was not found during exec