### PR TITLE
bugfix for bug 946978

### DIFF
--- a/Examples/WLAN_AMPM_DEVM_SEM/Program.cs
+++ b/Examples/WLAN_AMPM_DEVM_SEM/Program.cs
@@ -6,7 +6,7 @@ namespace NationalInstruments.ReferenceDesignLibraries.Examples
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Example Application WLAN_DPD_CFR_AMPM_EVM_SEM\n");
+            Console.WriteLine("Example Application WLAN_AMPM_DEVM_SEM\n");
             WLAN_AMPM_DEVM_SEM wlanDpdCfrAmPmDevmSem = new WLAN_AMPM_DEVM_SEM();
             try
             {

--- a/Source/SG/SG.cs
+++ b/Source/SG/SG.cs
@@ -152,6 +152,8 @@ namespace NationalInstruments.ReferenceDesignLibraries
         /// <param name="instrConfig">The common instrument settings to configure.</param>
         public static void ConfigureInstrument(NIRfsg rfsgHandle, InstrumentConfiguration instrConfig)
         {
+            rfsgHandle.Utility.Reset();
+
             rfsgHandle.SignalPath.SelectedPorts = instrConfig.SelectedPorts;
             rfsgHandle.RF.ExternalGain = -instrConfig.ExternalAttenuation_dB;
             rfsgHandle.RF.Configure(instrConfig.CarrierFrequency_Hz, instrConfig.DutAverageInputPower_dBm);

--- a/Source/SG/SG.cs
+++ b/Source/SG/SG.cs
@@ -152,8 +152,6 @@ namespace NationalInstruments.ReferenceDesignLibraries
         /// <param name="instrConfig">The common instrument settings to configure.</param>
         public static void ConfigureInstrument(NIRfsg rfsgHandle, InstrumentConfiguration instrConfig)
         {
-            rfsgHandle.Utility.Reset();
-
             rfsgHandle.SignalPath.SelectedPorts = instrConfig.SelectedPorts;
             rfsgHandle.RF.ExternalGain = -instrConfig.ExternalAttenuation_dB;
             rfsgHandle.RF.Configure(instrConfig.CarrierFrequency_Hz, instrConfig.DutAverageInputPower_dBm);


### PR DESCRIPTION
CHANGE: Add RFSG reset to "ConfigureInstrument" to start the generation from a default state.
INFO: Especially when the execution is stopped right after the rfsg Initiate (breakpoint + stop exe) in case of bursted generation (for PAenable).
INFO: The previous script trigger is not send and this results in a shift of the active and idle section of the PAenable signal.
CHANGE: Correct output name of the DEVM example.